### PR TITLE
\copytmppdffile proposal

### DIFF
--- a/PharmTeX.sty
+++ b/PharmTeX.sty
@@ -1623,6 +1623,11 @@ binmode(STDOUT, ":utf8");
 my $file = $_[0];
 my ($fname) = $file =~ /\/*([^\/]+?)$/;
 $fname =~ s/(.+)\..+?$/$1/g;
+if ($fname =~/.*\.tmppdf$/) {
+	my $fbase = "$fname";
+	$fname = "$fname.pdf";
+	return "\\renewcommand{\\fname}{$fname}\\renewcommand{\\fbase}{$fbase}";
+}
 my $fbase = "$fname.tmppdf";
 $fname = "$fname.tmppdf.pdf";
 if (!-e $fname) { copy $file, $fname; }


### PR DESCRIPTION
In our grid setup, the current `copytmppdffile` command appends "tmppdf" multiple times, and runs into issues copying the file, seemingly corrupting the resulting copy. The cause in issues copying the file is unknown, but the proposed change prevents creating copies of copies, which seems to resolve the issue.